### PR TITLE
updated to version 2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,16 @@
-swarm:
-  build: .
-  environment:
-    JENKINS_MASTER: 'jenkins'
-  links:
-   - jenkins
-jenkins:
-  build: jenkins/
-  ports:
-     - "8080:8080"
-     - "50000:50000"
-     - "36088:36088"
+version: '2'
+services:
+    swarm:
+        build: .
+        environment:
+            JENKINS_MASTER: 'jenkins'
+        depends_on:
+            - jenkins
+
+    jenkins:
+        build: jenkins/
+        ports:
+            - "8080:8080"
+            - "50000:50000"
+            - "36088:36088"
+            


### PR DESCRIPTION
`link` is no longer necessary
`depends_on` tells docker-compose to start `jenkins` before the swarm